### PR TITLE
create_final_json: replace assignment with append in error handling

### DIFF
--- a/bin/create_final_json.py
+++ b/bin/create_final_json.py
@@ -93,9 +93,9 @@ def read_and_parse_input_files(stats_file, report_file):
     if ((no_warning_message == 1) & (num_warnings == 1) & (num_errors > 0)):
         warnings = []
         if num_errors == 1:
-            warnings.append = "there was %d error but no warnings" %num_errors
+            warnings.append("there was %d error but no warnings" %num_errors)
         elif num_errors > 1:
-            warnings.append = "there was %d errors but no warnings" %num_errors
+            warnings.append("there was %d errors but no warnings" %num_errors)
         report['warnings'] = warnings
     
     out = copy.deepcopy(report)


### PR DESCRIPTION
Relating to issue #27: `warnings` list is now appended to and report contains and errors field to allow for successful termination of error-laden sample.