### PR TITLE
retry strategy for downloads

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -75,8 +75,8 @@ profiles {
       }
 
       withName:downloadContamGenomes {
-        // disable strict error checking to allow for non-matching lines in linktestlog.txt
-        shell = ['/bin/bash','-u']
+        errorStrategy = { task.exitStatus in 100..113 ? 'retry' : 'terminate' }
+        maxRetries = 5
       }
 
       withLabel:clockwork {
@@ -116,8 +116,8 @@ profiles {
       }
 
       withName:downloadContamGenomes {
-        // disable strict error checking to allow for non-matching lines in linktestlog.txt
-        shell = ['/bin/bash','-u']
+        errorStrategy = { task.exitStatus in 100..113 ? 'retry' : 'terminate' }
+        maxRetries = 5
       }
 
       withLabel:clockwork {
@@ -153,8 +153,8 @@ profiles {
       }
 
       withName:downloadContamGenomes {
-        // disable strict error checking to allow for non-matching lines in linktestlog.txt
-        shell = ['/bin/bash','-u']
+        errorStrategy = { task.exitStatus in 100..113 ? 'retry' : 'terminate' }
+        maxRetries = 5
       }
 
        withLabel:clockwork {


### PR DESCRIPTION
Added in "errorStrategy" to retry anny download related errors (100-112) as well as remove stricut bash flag -u. This may be needed to be added back in `linktestlog.txt`. Relating to #20 